### PR TITLE
Fix a problem with the implementation of dexterity support at plone.app....

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,10 +4,16 @@ Changelog
 0.1 (unreleased)
 ----------------
 
-- use `index` instead of `template` for info viewlet to allow overriding the 
+* use `index` instead of `template` for info viewlet to allow overriding the 
   template with zcml registrations (sync approach with that used in 
   p.a.iterate)
   [cewing]
+
+* Fix a problem with the implementation of dexterity support at plone.app.linkintegrity,
+  when this behavior is used with plone.app.referenceablebehavior the delete_confirmation form
+  was failing because the object than is being deleted doesn't have an intid.
+  With this patch the get_relations method simply returns an empty list in this case.
+  [jpgimenez]
 
 0.1b4 (2012-08-20)
 ------------------

--- a/plone/app/stagingbehavior/utils.py
+++ b/plone/app/stagingbehavior/utils.py
@@ -9,7 +9,11 @@ def get_relations( context ):
     context = aq_inner( context )
     # get id
     intids = component.getUtility( IIntIds )
-    id = intids.getId(aq_base(context))
+    id = intids.queryId(aq_base(context))
+    if not id:
+        # for objects without intid or
+        # objects being deleted in the current transaction return empty list
+        return []
     # ask catalog
     catalog = component.getUtility( ICatalog )
     relations = list(catalog.findRelations({ 'to_id' : id }))


### PR DESCRIPTION
...linkintegrity,

when this behavior is used with plone.app.referenceablebehavior the delete_confirmation form
was failing because the object than is being deleted doesn't have an intid.
With this patch the get_relations method simply returns an empty list in this case.
